### PR TITLE
Fixing RenderOverflow in Automaton Page

### DIFF
--- a/lib/pages/AutomatonPage.dart
+++ b/lib/pages/AutomatonPage.dart
@@ -58,10 +58,12 @@ class _AutomatonPageState extends State<AutomatonPage> {
             SizedBox(height: MediaQuery.of(context).size.height * 0.05),
             generateFunctionalities(),
             SizedBox(height: MediaQuery.of(context).size.height * 0.03),
-            CellGrid(
-              pretty: widget.beautify_mode,
-              grid: widget.grid,
-              initPage: false,
+            Expanded(
+              child: CellGrid(
+                pretty: widget.beautify_mode,
+                grid: widget.grid,
+                initPage: false,
+              ),
             ),
             SizedBox(height: MediaQuery.of(context).size.height * 0.02),
           ],


### PR DESCRIPTION
# Description

- Fixed ```RenderOverflowError``` on ```AutomatonPage```
  - A ```RenderOverflowError``` occurs on the ```AutomatonPage``` if the user inputs a grid where rows>>columns(eg 70*2) since 
    the entire grid doesn't fit on-screen, causing scrolling to be prevented, but not killing the ```root isolate``` .
  - This has been fixed by wrapping the ```GridView```  widget in an  ```Expanded``` widget.
  
- Big thank you to [Anshul](https://github.com/ArchUsr64) for spotting the bug. (God knows how much this man plays around 
  with input values XD)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
